### PR TITLE
Change `mul`s to `shl`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 | VERSION             | GAS CONSUMED |
 | ------------------- | ------------ |
 | Solidity (1 input)  | 207009       |
-| Huff (1 input)      | 188766       |
+| Huff (1 input)      | 188762       |
 | Solidity (2 inputs) | 215009       |
-| Huff (2 inputs)     | 195362       |
+| Huff (2 inputs)     | 195354       |
 
 ## Usage
 

--- a/src/contracts/VerifierTemplate.huff
+++ b/src/contracts/VerifierTemplate.huff
@@ -400,7 +400,7 @@
         0x00                      // [loop_index, input_len, input_ptr, snark_scalar]
         linear_combination:
             // Load input[i] onto the stack
-            dup1 0x20 mul         // [loop_index * 0x20, loop_index, input_len, input_ptr, snark_scalar]
+            dup1 0x05 shl         // [loop_index * 0x20, loop_index, input_len, input_ptr, snark_scalar]
             dup4 add              // [input_ptr + loop_index * 0x20, loop_index, input_len, input_ptr, snark_scalar]
             dup5                  // [snark_scalar, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
             dup2 mload            // [input[i], snark_scalar, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
@@ -411,7 +411,7 @@
 
             // Scalar mul IC[i + 1], input[i]
             [IC_PTR_SECOND]              // [ic_ptr, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
-            dup3 0x40 mul add     // [ic_ptr + loop_index + 0x40, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
+            dup3 0x06 shl add     // [ic_ptr + loop_index + 0x40, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
 
             // Store scalar mul result in scratch space @ 0x00
             SCALAR_MUL()          // [loop_index, input_len, input_ptr, snark_scalar]

--- a/test/multi-input/SampleVerifier.huff
+++ b/test/multi-input/SampleVerifier.huff
@@ -400,9 +400,9 @@
         0x00                      // [loop_index, input_len, input_ptr, snark_scalar]
         linear_combination:
             // Load input[i] onto the stack
-            dup1 0x20 mul         // [loop_index * 0x20, loop_index, input_len, input_ptr, snark_scalar]
+            dup1 0x05 shl         // [loop_index * 0x20, loop_index, input_len, input_ptr, snark_scalar]
             dup4 add              // [input_ptr + loop_index * 0x20, loop_index, input_len, input_ptr, snark_scalar]
-            dup5                  // [snark_scalar, input_ptr + loop_index * 0x20, loop_index, input_len, input_ptr, snark_scalar]
+            dup5                  // [snark_scalar, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
             dup2 mload            // [input[i], snark_scalar, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
 
             // require(input[i] < snark_scalar)
@@ -411,7 +411,7 @@
 
             // Scalar mul IC[i + 1], input[i]
             [IC_PTR_SECOND]              // [ic_ptr, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
-            dup3 0x40 mul add     // [ic_ptr + loop_index + 0x40, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
+            dup3 0x06 shl add     // [ic_ptr + loop_index + 0x40, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
 
             // Store scalar mul result in scratch space @ 0x00
             SCALAR_MUL()          // [loop_index, input_len, input_ptr, snark_scalar]

--- a/test/single-input/SampleVerifier.huff
+++ b/test/single-input/SampleVerifier.huff
@@ -400,9 +400,9 @@
         0x00                      // [loop_index, input_len, input_ptr, snark_scalar]
         linear_combination:
             // Load input[i] onto the stack
-            dup1 0x20 mul         // [loop_index * 0x20, loop_index, input_len, input_ptr, snark_scalar]
+            dup1 0x05 shl         // [loop_index * 0x20, loop_index, input_len, input_ptr, snark_scalar]
             dup4 add              // [input_ptr + loop_index * 0x20, loop_index, input_len, input_ptr, snark_scalar]
-            dup5                  // [snark_scalar, input_ptr + loop_index * 0x20, loop_index, input_len, input_ptr, snark_scalar]
+            dup5                  // [snark_scalar, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
             dup2 mload            // [input[i], snark_scalar, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
 
             // require(input[i] < snark_scalar)
@@ -411,7 +411,7 @@
 
             // Scalar mul IC[i + 1], input[i]
             [IC_PTR_SECOND]              // [ic_ptr, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
-            dup3 0x40 mul add     // [ic_ptr + loop_index + 0x40, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
+            dup3 0x06 shl add     // [ic_ptr + loop_index + 0x40, cur_input_offset, loop_index, input_len, input_ptr, snark_scalar]
 
             // Store scalar mul result in scratch space @ 0x00
             SCALAR_MUL()          // [loop_index, input_len, input_ptr, snark_scalar]


### PR DESCRIPTION
## Overview

Changes `mul` opcodes in `VERIFY` to `shl` ops.

### Gas Report

| VERSION             | GAS CONSUMED |
| ------------------- | ------------ |
| Solidity (1 input)  | 207009       |
| Huff (1 input)      | 188762       |
| Solidity (2 inputs) | 215009       |
| Huff (2 inputs)     | 195354       |